### PR TITLE
82 multistack pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,11 +17,14 @@ node("master") {
 def manageStack(stack_name, branch_name, dependsOn = null) {
     dir("terraform/") {
         def script = "${pwd()}/bin/manage-stack.sh"
-        def args = "-v -v --action create"
+        def args = []
         sh "chmod 700 '${script}'"
+        args << "-v"
+        args << "-v"
+        args << "--action create"
         if (dependsOn) {
-            args += "--input stack-output:///infrastructure/${env.BRANCH_NAME}"
+            args << "--input stack-output:///infrastructure/${env.BRANCH_NAME}"
         }
-        sh "'${script}' ${args} '${stack_name}' '${branch_name}'"
+        sh "'${script}' ${args.join(' ')} '${stack_name}' '${branch_name}'"
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,27 @@
-stage 'Create pilot stack'
+stage 'Initialize'
 node("master") {
     checkout scm
+}
+
+stage 'Create/Update Infrastructure Stack'
+node("master") {
+    manageStack('infrastructure', env.BRANCH_NAME)
+}
+
+stage 'Create/Update Pilot Stack'
+node("master") {
+    manageStack('pilot', env.BRANCH_NAME, "infrastructure")
+}
+
+
+def manageStack(stack_name, branch_name, dependsOn = null) {
     dir("terraform/") {
         def script = "${pwd()}/bin/manage-stack.sh"
+        def args = "-v -v --action create"
         sh "chmod 700 '${script}'"
-        sh "'${script}' -v -v --action create pilot '${env.BRANCH_NAME}'"
+        if (dependsOn) {
+            args += "--input stack-output:///infrastructure/${env.BRANCH_NAME}"
+        }
+        sh "'${script}' ${args} '${stack_name}' '${branch_name}'"
     }
 }


### PR DESCRIPTION
Changed (main) Jenkins pipeline to:

1.Create an infrastructure stack, using the branch name
2 Create a pilot stack (bastion and monitor instances) using subnet and security group output from the infrastructure stack, also using on the (same) branch name.

NOTE: To get Jenkins to build infrastructure for a specific branch (using the Provisioning Pipeline) add the branch name in the included branches. This is to avoid building infrastructure for all unrelated branches, as this repository has a multi-purpose.

#82