### PR TITLE
97 separate stacks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,12 @@ def runPipeline(pipeline) {
 
 
 def runStages(pipeline, environment) {
-    if (isDev(environment) || isMaster()) {
+	def isDev = isDev(environment)
+    if (isDev || isMaster()) {
         //initialize(environment)
+        if (!isDev) {
+        	proceed(pipeline, environment)
+        }
         provision(pipeline, environment)
         test(pipeline, environment)
         // do other stages here
@@ -43,9 +47,19 @@ def runStages(pipeline, environment) {
     }
 }
 
+def proceed(pipeline, environment) {
+	def label = getLabel(environment)
+    stage("${pipeline}-${label}: Proceed?") {
+    	node('master') {
+			timeout(time:5, unit:'DAYS') {
+              	input "Do you want to continue to ${label}?"
+            }
+         }
+    }
+}
 
 def provision(pipeline, environment) {
-    stage("${getLabel(environment)} - ${pipeline}: Provision") {
+    stage("${pipeline}-${getLabel(environment)}: Provision") {
         node('master') {
             getPipeline().provision(nameEnvironment(environment))
         }
@@ -53,7 +67,7 @@ def provision(pipeline, environment) {
 }
 
 def test(pipeline, environment) {
-    stage("${getLabel(environment)} - ${pipeline}: Test") {
+    stage("${pipeline}-${getLabel(environment)}: Test") {
         node('master') {
             getPipeline().test(nameEnvironment(environment))
         }
@@ -104,9 +118,9 @@ def getPipelineName() {
 
 def getPipelineSelectors() {
 	def selectors = []
-	selectors << [selector:/.*d2d.*/,                 pipeline: "d2d" ]
-	selectors << [selector:/.*datagov.*terraform.*/,  pipeline: "datagov-terraform" ]
-	selectors << [selector:/.*datagov.*ansible.*/,    pipeline: "datagov-ansible" ]
+	selectors << [selector:/.*d2d.*/,             pipeline: "d2d" ]
+	selectors << [selector:/.*datagov.*infra.*/,  pipeline: "datagov-infrastructure" ]
+	selectors << [selector:/.*datagov.*pilot.*/,  pipeline: "datagov-pilot" ]
 	return selectors
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ def runStages(pipeline, environment) {
         test(pipeline, environment)
         // do other stages here
     } else {
-    echo "Skipping ${environment}, because feature branch (${env.BRANCH_NAME})"
+    	echo "Skipping ${environment}, because feature branch (${env.BRANCH_NAME})"
     }
 }
 

--- a/jenkins/pipeline/datagov-infrastructure.groovy
+++ b/jenkins/pipeline/datagov-infrastructure.groovy
@@ -9,7 +9,6 @@ def initialize(environment) {
 def provision(environment) {
     def terraform = load "./jenkins/provisioner/terraform.groovy"
     terraform.run('infrastructure', environment)   
-    terraform.run('pilot', environment, "infrastructure")   
 }
 
 def test(environment) {

--- a/jenkins/pipeline/datagov-pilot.groovy
+++ b/jenkins/pipeline/datagov-pilot.groovy
@@ -7,6 +7,9 @@ def initialize(environment) {
 }
 
 def provision(environment) {
+    def terraform = load "./jenkins/provisioner/terraform.groovy"
+    terraform.run('pilot', environment, "infrastructure")   
+
     def playbook = load "./jenkins/provisioner/playbook.groovy"
     playbook.run("jumpbox", "pilot", environment, 
         "always,jumpbox,apache", "shibboleth", "bastion")

--- a/jenkins/pipeline/full.groovy
+++ b/jenkins/pipeline/full.groovy
@@ -6,8 +6,8 @@ def initialize(environment) {
 }
 
 def provision(environment) {
-    runPipeline('datagov-terraform', environment)
-    runPipeline('datagov-ansible', environment)
+    runPipeline('datagov-infrastructure', environment)
+    runPipeline('datagov-pilot', environment)
     runPipeline('d2d', environment)
 }
 


### PR DESCRIPTION
Separated pipelines into:

1. Infrastructure Terraform stack
2. Pilot Terraform stack + Ansible playbooks (provision jumpbox and  web-wordpress servers)
3. D2D Cloud Formation stack (provision bastion server)

To execute pipeline in a Jenkins job, include the following in the name (respectively):
1. terraform.*infra
2. terraform.*pilot
3. d2d

Additionally, re-added the pipeline "input" to require manual confirmation before proceeding to the production environment