### PR TITLE
Raise CRM PHP memory_limit

### DIFF
--- a/ansible/inventories/production/group_vars/crm-web/vars.yml
+++ b/ansible/inventories/production/group_vars/crm-web/vars.yml
@@ -9,6 +9,9 @@ env_db_name: "{{ vault_env_db_name }}"
 # Disabling MySQL server
 mysql_enabled_on_startup: false
 
+# PHP
+php_memory_limit: 1G
+
 # Composer
 project_git_repo: https://github.com/GSA/open311-simple-crm.git
 project_git_version: ansible

--- a/ansible/inventories/staging/group_vars/crm-web/vars.yml
+++ b/ansible/inventories/staging/group_vars/crm-web/vars.yml
@@ -9,6 +9,9 @@ env_db_name: "{{ vault_env_db_name }}"
 # Disabling MySQL server
 mysql_enabled_on_startup: false
 
+# PHP
+php_memory_limit: 1G
+
 # Composer
 project_git_repo: https://github.com/GSA/open311-simple-crm.git
 project_git_version: ansible

--- a/ansible/inventories/vsl4/group_vars/crm-web/vars.yml
+++ b/ansible/inventories/vsl4/group_vars/crm-web/vars.yml
@@ -9,6 +9,9 @@ env_db_name: "{{ vault_env_db_name }}"
 # Disabling MySQL server
 mysql_enabled_on_startup: false
 
+# PHP
+php_memory_limit: 1G
+
 # Composer
 project_git_repo: https://github.com/GSA/open311-simple-crm.git
 project_git_version: ansible


### PR DESCRIPTION
In some cases, default 256M memory_limit was not enough. Temporarily raising to 1G till the data is taken in chunks from DB or another memory management improvement is applied to CRM code

https://labs.data.gov/crm/admin/reports_csv
https://labs.data.gov/crm/admin/index/export