### PR TITLE
Dashboard :: Add cronjob to download json

### DIFF
--- a/ansible/roles/software/dashboard/dashboard-deploy/tasks/main.yml
+++ b/ansible/roles/software/dashboard/dashboard-deploy/tasks/main.yml
@@ -103,10 +103,18 @@
     job: "/usr/bin/php {{ current_source_symlink }}/index.php campaign status cfo-act datajson | tee /var/log/dashboard-cron-cfo.log | mail -s 'LabsData - Dashboard (cfo-act datajson) - {{ real_ansible_env }} Cron Job' -a 'From: {{ default_email_from }}' {{ cron_to_emails }}"
   when: crons_enabled
 
+- name: Set up campaign status cfo-act download cron job to run @ 11:15pm EST nightly
+  cron:
+    name: "campaign status cfo-act download cron job"
+    minute: 15
+    hour: 4
+    job: "/usr/bin/php {{ current_source_symlink }}/index.php campaign status cfo-act download | tee /var/log/dashboard-cron-cfo.log | mail -s 'LabsData - Dashboard (cfo-act download) - {{ real_ansible_env }} Cron Job' -a 'From: {{ default_email_from }}' {{ cron_to_emails }}"
+  when: crons_enabled
+
 - name: Set up campaign status cfo-act full-scan cron job to run @ 11:30pm EST nightly
   cron:
     name: "campaign status cfo-act full-scan cron job"
-    minute: 0
-    hour: 5
+    minute: 30
+    hour: 4
     job: "/usr/bin/php {{ current_source_symlink }}/index.php campaign status cfo-act full-scan | tee /var/log/dashboard-cron.log | mail -s 'LabsData - Dashboard (cfo-act full-scan) - {{ real_ansible_env }} Cron Job' -a 'From: {{ default_email_from }}' {{ cron_to_emails }}"
   when: crons_enabled


### PR DESCRIPTION
Dashboard cron (cfo-act datajson) was not saving .json files. Another cron (cfo-act full-scan) is dying somewhere in the middle and we don't get an email with results. It should download those files but doesn't. So we're adding now another cronjob (cfo-act download) just to download that .json files