### PR TITLE
Non existing groups

### DIFF
--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -23,3 +23,9 @@ wordpress-web[1:2]d.dev-ocsit.bsp.gsa.gov
 
 [jekyll-web]
 static-web1d.dev-ocsit.bsp.gsa.gov
+
+[elasticsearch]
+
+[kibana]
+
+[efk_nginx]

--- a/ansible/roles/software/common/trendmicro/tasks/main.yml
+++ b/ansible/roles/software/common/trendmicro/tasks/main.yml
@@ -30,10 +30,10 @@
 
 - name: start trendmicro agent @ mgmt web tier
   shell: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id_mgmt_web }}"
-  when: inventory_hostname in groups["efk_nginx"]
+  when: ("efk_nginx" in groups) and (inventory_hostname in groups["efk_nginx"])
 
 - name: start trendmicro agent @ mgmt app tier
   shell: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id_mgmt_app }}"
   when: | 
-    (inventory_hostname in groups["kibana"]) or 
-    (inventory_hostname in groups["elasticsearch"])
+    (("kibana" in groups) and (inventory_hostname in groups["kibana"])) or
+    (("elasticsearch" in groups) and (inventory_hostname in groups["elasticsearch"]))


### PR DESCRIPTION
Build fails when `inventory_hostname in groups["kibana"]` is used in condition, and group named `kibana` does not exist.
I've both added empty groups to staging inventory, and added additional checks like `if "kibana" in groups` 
In future any of those steps is required to avoid errors. I believe first one (with empty groups in inventories) is preferred.