### PR TITLE
Site url fixes for catalog

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,6 +46,7 @@ suites:
       playbook: ansible/catalog.yml
       extra_vars:
         redis_password: fake-redis-password
+        ckan_site_domain: http://test-kitchen-datagov.local
       ansible_extra_flags: >-
         --tags=frontend,ami-fix,bsp --skip-tags=solr,db,cron,skip_in_kitchen <%= ENV['ANSIBLE_EXTRA_FLAGS'] %>
   - name: catalog-harvester

--- a/ansible/inventories/doi/group_vars/all/vars.yml
+++ b/ansible/inventories/doi/group_vars/all/vars.yml
@@ -5,6 +5,7 @@ urls_public:
   catalog: https://placeholder
 urls_private:
   catalog: https://placeholder
+ckan_site_domain: "{{ urls_public.catalog }}"
 
 # solr
 solr_master_server: placeholder

--- a/ansible/inventories/production/group_vars/all/vars.yml
+++ b/ansible/inventories/production/group_vars/all/vars.yml
@@ -5,6 +5,7 @@ urls_public:
   catalog: https://catalog.data.gov
 urls_private:
   catalog: "{{ vault_urls_private_catalog }}"
+ckan_site_domain: "{{ urls_public.catalog }}"
 
 # s3 bucket
 catalog_bucket_name: "{{ vault_catalog_bucket_name }}"

--- a/ansible/inventories/staging/group_vars/all/vars.yml
+++ b/ansible/inventories/staging/group_vars/all/vars.yml
@@ -5,6 +5,7 @@ urls_public:
   catalog: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
 urls_private:
   catalog: https://catalog-datagov.dev-ocsit.bsp.gsa.gov
+ckan_site_domain: "{{ urls_public.catalog }}"
 
 # solr
 solr_master_server: datagovsolrm1d.dev-ocsit.bsp.gsa.gov

--- a/ansible/inventories/test/group_vars/all/vars.yml
+++ b/ansible/inventories/test/group_vars/all/vars.yml
@@ -5,6 +5,7 @@ urls_public:
   catalog: http://catalog-web-test.datagov.us
 urls_private:
   catalog: "{{ vault_urls_private_catalog }}"
+ckan_site_domain: "{{ urls_public.catalog }}"
 
 # s3 bucket
 catalog_bucket_name: "{{ vault_catalog_bucket_name }}"

--- a/ansible/roles/software/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/catalog/ckan-app/tasks/main.yml
@@ -13,7 +13,7 @@
   register: p
 
 - name: Create rollback code
-  command: cp -r "{{ project_source_new_code_path }}" "{{ project_source_rollback_path }}"
+  command: cp --recursive --preserve "{{ project_source_new_code_path }}" "{{ project_source_rollback_path }}"
   when: p.stat.isdir is defined and p.stat.isdir
   tags: skip_ansible_lint
 

--- a/ansible/roles/software/catalog/ckan-app/tasks/main.yml
+++ b/ansible/roles/software/catalog/ckan-app/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: build dependencies
+  apt: name={{ item }} state=present
+  with_items:
+    - xmlsec1
+    - swig
 
 - name: Remove old rollback code
   file: path="{{ project_source_rollback_path }}" state=absent

--- a/ansible/roles/software/ckan/common/tasks/main.yml
+++ b/ansible/roles/software/ckan/common/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create ckan config dir
-  action: file path=/etc/ckan state=directory follow=yes
+  action: file path=/etc/ckan state=directory owner=root group=www-data mode=0750 follow=yes
 
 - name: copy executables
   action: copy src={{item}} dest=/{{item}} mode=0744


### PR DESCRIPTION
Dev/test instances are not setting the site_url correctly, they are defaulting to `https://catalog.data.gov`. Each environment has their own unique URL.

cc @hareeshreddyg 