### PR TITLE
Apply python_home to all hosts

### DIFF
--- a/ansible/catalog.yml
+++ b/ansible/catalog.yml
@@ -22,9 +22,7 @@
     - {role: monitoring/fluentd/kernel, tags: ['bsp', 'fluentd'] }
     - {role: monitoring/fluentd/limits, tags: ['bsp', 'fluentd'] }
     - {role: monitoring/fluentd/td-agent, tags: ['bsp', 'fluentd', 'skip_in_kitchen'] }
-    - role: gsa.datagov-deploy-apache2
-      python_home: "{{ python_version_directory }}"
-      tags: ['frontend', 'apache']
+    - {role: gsa.datagov-deploy-apache2, tags: ['frontend', 'apache']}
     - {role: software/ckan/postgresql, tags: ['frontend', 'harvester', 'db', 'db-install']}
     - {role: software/ckan/solr, tags: ['frontend', 'harvester', 'solr']}
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -15,6 +15,7 @@ python_version_number: 2.7.10
 python_version_name: Python-{{ python_version_number }}
 python_version_url: https://www.python.org/ftp/python/{{ python_version_number}}/{{ python_version_name }}.tgz
 python_version_directory: /usr/local/lib/python{{ python_version_number }}/
+python_home: "{{ python_version_directory }}"
 
 # Disabling MySQL server (we need only client on this machine)
 mysql_enabled_on_startup: false

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -18,7 +18,6 @@
     - {role: monitoring/fluentd/td-agent, tags: ['bsp', 'fluentd', 'skip_in_kitchen'] }
     - software/ckan/common
     - role: gsa.datagov-deploy-apache2
-      python_home: "{{ python_version_directory }}"
     - {role: software/ckan/postgresql, tags: ['db', 'db-install']}
     - {role: software/ckan/solr, tags: ['solr']}
     - {role: software/inventory/ckan-app, tags: ['deploy']}


### PR DESCRIPTION
Fixes #430 

This moves `python_home` up to all hosts. This fixes apache on the jekyll hosts not starting up correctly.