### PR TITLE
Add Ansible role for CI

### DIFF
--- a/ansible/ci.yml
+++ b/ansible/ci.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Setup CI
+  hosts: vagrant
+  remote_user: vagrant
+  become: yes
+  become_method: sudo
+
+  roles:
+#  - { role: geerlingguy.git, tags: [git, provision] }
+  - role: ci

--- a/ansible/roles/ci/.gitignore
+++ b/ansible/roles/ci/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/ansible/roles/ci/.yamllint
+++ b/ansible/roles/ci/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/ansible/roles/ci/README.md
+++ b/ansible/roles/ci/README.md
@@ -1,0 +1,48 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should
+be mentioned here. For instance, if the role uses the EC2 module, it may be a
+good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including
+any variables that are in defaults/main.yml, vars/main.yml, and any variables
+that can/should be set via parameters to the role. Any variables that are read
+from other roles and/or the global scope (ie. hostvars, group vars, etc.) should
+be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in
+regards to parameters that may need to be set for other roles, or variables that
+are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables
+passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: ci, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a
+website (HTML is not allowed).

--- a/ansible/roles/ci/defaults/main.yml
+++ b/ansible/roles/ci/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+users:
+  - { username: 'ci' }

--- a/ansible/roles/ci/handlers/main.yml
+++ b/ansible/roles/ci/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ci

--- a/ansible/roles/ci/meta/main.yml
+++ b/ansible/roles/ci/meta/main.yml
@@ -1,0 +1,58 @@
+---
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  # github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.

--- a/ansible/roles/ci/molecule/default/Dockerfile.j2
+++ b/ansible/roles/ci/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/ansible/roles/ci/molecule/default/INSTALL.rst
+++ b/ansible/roles/ci/molecule/default/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/ansible/roles/ci/molecule/default/molecule.yml
+++ b/ansible/roles/ci/molecule/default/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    image: centos:7
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  env:
+    ANSIBLE_ROLES_PATH: ../../../../roles/vendor/
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/ansible/roles/ci/molecule/default/playbook.yml
+++ b/ansible/roles/ci/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: ci

--- a/ansible/roles/ci/molecule/default/requirements.yml
+++ b/ansible/roles/ci/molecule/default/requirements.yml
@@ -1,0 +1,3 @@
+---
+- name: git
+  src: geerlingguy.git

--- a/ansible/roles/ci/molecule/default/tests/test_default.py
+++ b/ansible/roles/ci/molecule/default/tests/test_default.py
@@ -1,0 +1,38 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'
+
+
+def test_user(host):
+    user = host.user("ci")
+    assert user.exists
+    assert user.name == "ci"
+    assert user.group == "ci"
+    assert user.groups == ["ci"]
+    assert user.shell == "/bin/bash"
+    assert user.home == "/home/ci"
+
+
+def test_datagov_deploy_repo(host):
+    repo = host.file("/home/ci/datagov-deploy")
+    assert repo.is_directory
+    assert host.check_output(
+        "cd /home/ci/datagov-deploy && git symbolic-ref --short HEAD"
+    ) == "bsp-ci"
+
+
+def test_cron_job(host):
+    assert host.check_output(
+        "crontab -l -u ci"
+    ) == "0 12 * * * /home/ci/datagov-deploy/ci.sh"

--- a/ansible/roles/ci/tasks/main.yml
+++ b/ansible/roles/ci/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Create the ci user
+  user:
+    name: "{{ item.username }}"
+    comment: "{{ item.username }}"
+    # password: "cipass"
+    # groups:
+    #   - sudo
+    state: present
+    shell: /bin/bash
+    system: true
+    createhome: false
+  with_items: "{{ users }}"
+
+- name: Install git
+  include_role:
+    name: geerlingguy.git
+
+- name: Clone the datagov-deploy repo
+  git:
+    repo: "https://github.com/GSA/datagov-deploy"
+    dest: "/home/{{ item.username }}/datagov-deploy"
+    version: bsp-ci
+  with_items: "{{ users }}"
+
+- name: Add the ci script to crontab
+  cron:
+    name: "The CI script"
+    minute: "0"
+    hour: "12"
+    job: "/home/{{ item.username }}/datagov-deploy/ci.sh"
+  with_items: "{{ users }}"
+  become: true
+  become_user: "{{ item.username }}"

--- a/ansible/roles/ci/vars/main.yml
+++ b/ansible/roles/ci/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ci


### PR DESCRIPTION
The role sets up a new `ci` user, clones the `datagov-deploy` repo
and adds the `ci.sh` script as a cron job.