### PR TITLE
CI refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,142 @@
+test-molecule-steps: &test-molecule-steps
+  - checkout
+  - restore_cache:
+      keys:
+        - v1-pip-{{ checksum "requirements.txt" }}
+        - v1-pip-
+  - run: |
+      virtualenv venv
+      . venv/bin/activate
+      pip install -r requirements.txt
+  - save_cache:
+      key: v1-pip-{{ checksum "requirements.txt" }}
+      paths:
+        - venv
+  - run:
+      name: Run molecule
+      command: |
+        . venv/bin/activate
+        make test-molecule-$MOLECULE_SUITE
+
+
+test-kitchen-steps: &test-kitchen-steps
+  - checkout
+  - restore_cache:
+      keys:
+        - v1-bundle-{{ checksum "Gemfile.lock" }}
+        - v1-bundle-
+  - run:
+      name: Install dependencies
+      command: bundle install --path vendor/bundle
+  - save_cache:
+      key: v1-bundle-{{ checksum "Gemfile.lock" }}
+      paths:
+        - vendor/bundle
+  - run:
+      name: Run test-kitchen
+      command: make test-kitchen-$KITCHEN_SUITE
+
+
 version: 2
 jobs:
   lint:
     docker:
       # specify the version you desire here
       - image: particlekit/ansible-lint
-
     working_directory: ~/repo
-
     steps:
       - run: ansible-lint --version
       - checkout
       - run: echo 'password' > ~/ansible-secret.txt
       - run: make lint
 
-  test-kitchen:
+  test-kitchen-catalog-web:
     machine: true
     environment:
-      KITCHEN_CONCURRENCY: "4"
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-bundle-{{ checksum "Gemfile.lock" }}
-      - run: pip install -r requirements.txt
-      - run:
-          name: Install dependencies
-          command: bundle install --path vendor/bundle
-      - save_cache:
-          key: v1-bundle-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-      - run:
-          name: Run test-kitchen
-          command: make test
+      KITCHEN_SUITE: catalog-web
+    steps: *test-kitchen-steps
+
+  test-kitchen-catalog-harvester:
+    machine: true
+    environment:
+      KITCHEN_SUITE: catalog-harvester
+    steps: *test-kitchen-steps
+
+  test-kitchen-crm-web:
+    machine: true
+    environment:
+      KITCHEN_SUITE: crm-web
+    steps: *test-kitchen-steps
+
+  test-kitchen-dashboard-web:
+    machine: true
+    environment:
+      KITCHEN_SUITE: dashboard-web
+    steps: *test-kitchen-steps
+
+  test-kitchen-efk-nginx:
+    machine: true
+    environment:
+      KITCHEN_SUITE: efk-nginx
+    steps: *test-kitchen-steps
+
+  test-kitchen-efk-stack:
+    machine: true
+    environment:
+      KITCHEN_SUITE: efk-stack
+    steps: *test-kitchen-steps
+
+  test-kitchen-inventory-web:
+    machine: true
+    environment:
+      KITCHEN_SUITE: inventory-web
+    steps: *test-kitchen-steps
+
+  test-kitchen-jekyll:
+    machine: true
+    environment:
+      KITCHEN_SUITE: jekyll
+    steps: *test-kitchen-steps
+
+  test-kitchen-logrotate:
+    machine: true
+    environment:
+      KITCHEN_SUITE: logrotate
+    steps: *test-kitchen-steps
+
+  test-kitchen-solr:
+    machine: true
+    environment:
+      KITCHEN_SUITE: solr
+    steps: *test-kitchen-steps
+
+  test-kitchen-web-proxy:
+    machine: true
+    environment:
+      KITCHEN_SUITE: web-proxy
+    steps: *test-kitchen-steps
+
+  test-molecule-software/ckan/native-login:
+    machine: true
+    environment:
+      MOLECULE_SUITE: software/ckan/native-login
+    steps: *test-molecule-steps
+
 
 workflows:
   version: 2
   commit:
     jobs:
       - lint
-      - test-kitchen
+      - test-kitchen-catalog-web
+      - test-kitchen-catalog-harvester
+      - test-kitchen-crm-web
+      - test-kitchen-dashboard-web
+      - test-kitchen-efk-nginx
+      - test-kitchen-efk-stack
+      - test-kitchen-inventory-web
+      - test-kitchen-jekyll
+      - test-kitchen-logrotate
+      - test-kitchen-solr
+      - test-kitchen-web-proxy
+      - test-molecule-software/ckan/native-login

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,12 +104,6 @@ jobs:
       KITCHEN_SUITE: logrotate
     steps: *test-kitchen-steps
 
-  test-kitchen-solr:
-    machine: true
-    environment:
-      KITCHEN_SUITE: solr
-    steps: *test-kitchen-steps
-
   test-kitchen-web-proxy:
     machine: true
     environment:
@@ -137,6 +131,5 @@ workflows:
       - test-kitchen-inventory-web
       - test-kitchen-jekyll
       - test-kitchen-logrotate
-      - test-kitchen-solr
       - test-kitchen-web-proxy
       - test-molecule-software/ckan/native-login

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ KITCHEN_SUITES := \
   inventory-web \
   jekyll \
   logrotate \
-  solr \
   web-proxy
 
 MOLECULE_SUITES := \

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Run the playbooks locally.
 
     $ make test
 
-You can set the concurrency parameter by environment variable.
+You can set the concurrency parameter with make's `-j` parameter.
 
-    $ KITCHEN_CONCURRENCY=4 make test
+    $ make -j4 test
 
 Run a single suite.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Moved to [datagov-infrastructure](https://github.com/gsa/datagov-infrastructure)
 
 `cd ansible`
 
-`ansible-playbook --help` 
+`ansible-playbook --help`
 
 See example(s) below
 
@@ -56,7 +56,7 @@ See example(s) below
 **deploy rollback:** `ansible-playbook datagov-web.yml -i {{ inventory }} --tags="deploy-rollback" --limit wordpress-web`
 
 - You can override branch to be deployed via `-e project_git_version=develop`
-  
+
   ***e.g.*** `ansible-playbook datagov-web.yml -i inventories/staging/hosts --tags=deploy --limit wordpress-web -e project_git_version=develop`
 
 ## Dashboard
@@ -144,6 +144,42 @@ You can set the concurrency parameter with make's `-j` parameter.
 
     $ make -j4 test
 
+This runs all the suites, both molecule and kitchen tests. See below for more on
+how to work with individual suites. Both suites rely on docker for running tests
+within containers.
+
+Lint your work.
+
+    $ make lint
+
+
+### Testing with molecule
+
+[Molecule](https://molecule.readthedocs.io/en/latest/) is the preferred test
+suite for testing roles. Playbooks can be tested by including them in the
+molecule playbook.
+
+Molecule is modular, so you must `cd` to the directory of the role you are
+testing.
+
+    $ cd roles/software/ckan/native-login
+    $ molecule test
+
+During development, you'll want to run only the converge playbook to avoid
+creating/destroying the container every time.
+
+    $ molecule converge
+
+If you have multiple scenarios, you can specify them individually.
+
+    $ moelcule test -s <scenario>
+
+
+### Testing with kitchen
+
+We use [Kitchen](https://kitchen.ci/) for testing playbooks, although we are
+moving suites to molecule.
+
 Run a single suite.
 
     $ cd ansible
@@ -157,10 +193,5 @@ Log into the instance to debug.
 Re-run the playbook from a particular step.
 
     $ ANSIBLE_EXTRA_FLAGS='--start-at-task="software/ckan/apache : make sure postgresql packages are installed"' bundle exec kitchen converge catalog
-
-Lint your work.
-
-    $ make lint
-
 
 Refer to [kitchen](https://kitchen.ci/) commands for more information.

--- a/ansible/roles/software/ckan/native-login/molecule/default/prepare.yml
+++ b/ansible/roles/software/ckan/native-login/molecule/default/prepare.yml
@@ -33,6 +33,12 @@
         version: "8.1.1"
         virtualenv: /usr/lib/ckan
 
+    - name: install newer version of setuptools
+      pip:
+        name: setuptools
+        version: "40.5.0"
+        virtualenv: /usr/lib/ckan
+
     - name: create ckan config directory
       file:
         dest: /etc/ckan

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ansible==2.5.2
 ansible-lint==3.4.23
 molecule
 docker-py
+pytest==3.9.3


### PR DESCRIPTION
This splits each molecule/kitchen suite into it's own makefile task and CircleCI job. This let's us run them concurrently locally, via `make -j<jobs>` and on CI.