### PR TITLE
[common] set umask before installing python

### DIFF
--- a/ansible/roles/software/ubuntu/common/tasks/python-upgrade.yml
+++ b/ansible/roles/software/ubuntu/common/tasks/python-upgrade.yml
@@ -29,7 +29,7 @@
   when: python_dir.stat.exists == False or python_version_check|failed or not python_shared_lib.stat.exists
 
 - name: install new python
-  shell: "make && make install"
+  shell: "umask 022; make && make install"
   args:
     chdir: /var/tmp/{{ python_version_name }}
   when: python_dir.stat.exists == False or python_version_check|failed or not python_shared_lib.stat.exists


### PR DESCRIPTION
The hardening playbook sets a global umask 027. If the python install happens
after the hardening playbook, python files will be installed where they are not
world-readable, meaning ckan will fail (among other things).