### PR TITLE
add harvest-object-relink to cronjob

### DIFF
--- a/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_misc_worker
+++ b/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_misc_worker
@@ -1,5 +1,6 @@
 @monthly root supervisorctl start ckan-metrics-csv > /dev/null
 
+#3 1 * * 0 root supervisorctl start ckan-harvest-object-relink
 #1 1 * * * root supervisorctl start ckan-clean-deleted
 #1 3 * * * root supervisorctl start ckan-tracking-update > /dev/null
 #30 23 * * * root supervisorctl start qa-update-sel:*

--- a/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_misc_worker.conf.j2
+++ b/ansible/roles/software/ckan/catalog/ckan-app/templates/supervisord_misc_worker.conf.j2
@@ -1,3 +1,10 @@
+[program:ckan-harvest-object-relink]
+command=ckan --plugin=ckanext-geodatagov geodatagov harvest-object-relink -c /etc/ckan/production.ini
+stdout_logfile=/var/log/ckan/harvest-object-relink.log
+redirect_stderr=true
+autostart=false
+autorestart=false
+
 [program:ckan-clean-deleted]
 command=ckan --plugin=ckanext-geodatagov geodatagov clean-deleted -c /etc/ckan/production.ini
 stdout_logfile=/var/log/ckan/clean-deleted.log


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/3403

Added the relink to cronjob but keep it disabled. We can run it manually once then check the result in next a few weeks to figure out appropriate cron schedule.

Waiting for https://github.com/GSA/ckanext-geodatagov/pull/194, then a requirement update for https://github.com/GSA/catalog.data.gov.

