### PR TITLE
Remove dashboard hosts

### DIFF
--- a/ansible/inventories/local/hosts
+++ b/ansible/inventories/local/hosts
@@ -2,7 +2,6 @@ local ansible_host=127.0.0.1 ansible_port=2222 ansible_user='vagrant' ansible_ho
 
 
 [dashboard-web]
-local
 
 [wordpress-web]
 local

--- a/ansible/inventories/mgmt/group_vars/all/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/all/vars.yml
@@ -110,9 +110,6 @@ jenkins_jobs:
   - name: deploy-ci-app-catalog-next
     git_url: https://github.com/gsa/catalog.data.gov.git
     git_ref: fcs
-  - name: deploy-ci-app-dashboard
-    git_url: https://github.com/gsa/project-open-data-dashboard.git
-    git_ref: fcs
   - name: deploy-ci-app-inventory
     git_url: https://github.com/gsa/inventory-app.git
     git_ref: fcs

--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -37,7 +37,6 @@ catalogbweb[1:2]p.prod-ocsit.bsp.gsa.gov
 dashboard-web-v2
 
 [dashboard-web-v2]
-dashboardweb[1:2]p.prod-ocsit.bsp.gsa.gov
 
 [efk_nginx]
 [elasticsearch]

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -18,7 +18,6 @@ catalog-harvester-next1tf.internal.sandbox.datagov.us
 catalog-next-web1tf.internal.sandbox.datagov.us
 
 [dashboard-web]
-dashboard-web1tf.internal.sandbox.datagov.us
 
 [jumpbox]
 datagov-jump1tf.internal.sandbox.datagov.us

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -36,7 +36,6 @@ catalogpubweb1d.dev-ocsit.bsp.gsa.gov
 dashboard-web-v2
 
 [dashboard-web-v2]
-dashboardweb[1:2]d.dev-ocsit.bsp.gsa.gov
 
 [efk_nginx]
 [elasticsearch]


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/3555

dashboard.data.gov is live on cloud.gov!

Remove the dashboard hosts from ansible/FCS.
