### PR TITLE
Remove inventory hosts

### DIFF
--- a/ansible/inventories/mgmt/group_vars/all/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/all/vars.yml
@@ -110,9 +110,6 @@ jenkins_jobs:
   - name: deploy-ci-app-catalog-next
     git_url: https://github.com/gsa/catalog.data.gov.git
     git_ref: fcs
-  - name: deploy-ci-app-inventory
-    git_url: https://github.com/gsa/inventory-app.git
-    git_ref: fcs
   - name: deploy-ci-app-wordpress
     git_url: https://github.com/gsa/datagov-wp-boilerplate.git
     git_ref: fcs

--- a/ansible/inventories/production/hosts
+++ b/ansible/inventories/production/hosts
@@ -42,7 +42,6 @@ dashboard-web-v2
 [elasticsearch]
 
 [inventory-next]
-inventory-[1:2]p.prod-ocsit.bsp.gsa.gov
 
 [jumpbox:children]
 jumpbox-v2

--- a/ansible/inventories/sandbox/hosts
+++ b/ansible/inventories/sandbox/hosts
@@ -26,7 +26,6 @@ datagov-jump1tf.internal.sandbox.datagov.us
 datagov-solr1tf.internal.sandbox.datagov.us
 
 [inventory-next]
-inventory-next-web1tf.internal.sandbox.datagov.us
 
 [jenkins]
 jenkins1tf.internal.sandbox.datagov.us

--- a/ansible/inventories/staging/hosts
+++ b/ansible/inventories/staging/hosts
@@ -41,7 +41,6 @@ dashboard-web-v2
 [elasticsearch]
 
 [inventory-next]
-inventory-[1:2]d.dev-ocsit.bsp.gsa.gov
 
 [jumpbox:children]
 jumpbox-v2


### PR DESCRIPTION
#3554

inventory.data.gov is live on cloud.gov!

Remove the inventory hosts from ansible/FCS.

(I'm copying what Aaron did [over here](https://github.com/GSA/datagov-deploy/pull/3581) for dashboard.)