### PR TITLE
Turn harvesters back on on FCS

### DIFF
--- a/ansible/inventories/production/group_vars/catalog-next-worker/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next-worker/vars.yml
@@ -3,7 +3,7 @@ datagov_app_process: worker
 
 catalog_app_type: worker
 
-datagov_in_service: false
+datagov_in_service: true
 
 # catalog-workers write to database
 catalog_ckan_db_host: "{{ catalog_next_ckan_db_primary_host }}"

--- a/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_main_worker
+++ b/ansible/roles/software/ckan/catalog/ckan-app/files/etc/cron.d/ckan_main_worker
@@ -1,1 +1,1 @@
-# */3 * * * * root supervisorctl start harvest-run > /dev/null
+*/3 * * * * root supervisorctl start harvest-run > /dev/null


### PR DESCRIPTION
Reverts #3599. New issues with SOLR rollout that don't have a definitive resolution date require us to turn harvesters back on, and do another DB dump at a later date.