### PR TITLE
update sandbox for idp certificate

### DIFF
--- a/ansible/inventories/sandbox/group_vars/all/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/all/vars.yml
@@ -151,8 +151,8 @@ jenkins_saml_sp_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:ci_datagov_s
 jenkins_saml_keystore_password: "{{ vault_jenkins_saml_keystore_password }}"
 jenkins_saml_keystore_path: "{{ playbook_dir }}/files/sandbox/saml-key.jks"
 jenkins_saml_private_key_password: "{{ vault_jenkins_saml_private_key_password }}"
-jenkins_saml_idp_metadata_url: https://idp.int.identitysandbox.gov/api/saml/metadata2021
-jenkins_saml_idp_logout_url: https://idp.int.identitysandbox.gov/api/saml/logout2021
+jenkins_saml_idp_metadata_url: https://idp.int.identitysandbox.gov/api/saml/metadata2022
+jenkins_saml_idp_logout_url: https://idp.int.identitysandbox.gov/api/saml/logout2022
 jenkins_system_message: >
   Data.gov sandbox continuous integration and delivery service.
 jenkins_host: jenkins1tf.internal.sandbox.datagov.us

--- a/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/catalog-next/vars.yml
@@ -19,10 +19,10 @@ catalog_ckan_plugins_default: "{{ catalog_next_ckan_plugins_default }}"
 catalog_ckan_plugins_additional: [saml2auth]
 
 # login.gov identity sandbox
-saml2_idp_metadata_url: "https://idp.int.identitysandbox.gov/api/saml/metadata2021"
+saml2_idp_metadata_url: "https://idp.int.identitysandbox.gov/api/saml/metadata2022"
 catalog_ckan_saml2_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-sandbox-catalog
 saml2_site_url: "https://catalog-next.sandbox.datagov.us/"
-saml2_idp_url: https://idp.int.identitysandbox.gov/api/saml/auth2021
+saml2_idp_url: https://idp.int.identitysandbox.gov/api/saml/auth2022
 saml2_sp_private_key: "{{ vault_catalog_next_saml2_sp_private_key }}"
 saml2_sp_public_certificate: |
   -----BEGIN CERTIFICATE-----

--- a/ansible/inventories/sandbox/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/sandbox/group_vars/inventory-next/vars.yml
@@ -41,7 +41,7 @@ ckan_production_ini_template: inventory-next/etc_ckan_production.ini.j2
 inventory_ckan_who_ini_path: inventory-next/etc_ckan_who.saml2.ini.j2
 
 # login.gov identity sandbox
-saml2_idp_metadata_url: "https://idp.int.identitysandbox.gov/api/saml/metadata2021"
+saml2_idp_metadata_url: "https://idp.int.identitysandbox.gov/api/saml/metadata2022"
 saml2_site_url: "https://inventory-next.sandbox.datagov.us/"
 
 saml2_sp_public_certificate: "{{ vault_inventory_next_saml2_sp_public_certificate }}"


### PR DESCRIPTION
Part of https://github.com/GSA/datagov-deploy/issues/3659.

Updated IdP only. SP certificate is not expiring any time soon, no update.

Tested on AWS sandbox.