### PR TITLE
Login.gov 2022 SAML IdP certificate rotation

### DIFF
--- a/ansible/inventories/mgmt/group_vars/all/vars.yml
+++ b/ansible/inventories/mgmt/group_vars/all/vars.yml
@@ -116,8 +116,8 @@ jenkins_saml_sp_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-ci-j
 jenkins_saml_keystore_password: "{{ vault_jenkins_saml_keystore_password }}"
 jenkins_saml_keystore_path: "{{ playbook_dir }}/files/mgmt/saml-key.jks"
 jenkins_saml_private_key_password: "{{ vault_jenkins_saml_private_key_password }}"
-jenkins_saml_idp_metadata_url: https://secure.login.gov/api/saml/metadata2021
-jenkins_saml_idp_logout_url: https://secure.login.gov/api/saml/logout2021
+jenkins_saml_idp_metadata_url: https://secure.login.gov/api/saml/metadata2022
+jenkins_saml_idp_logout_url: https://secure.login.gov/api/saml/logout2022
 jenkins_system_message: >
   Data.gov continuous integration and delivery service.
 jenkins_home: /data/jenkins

--- a/ansible/inventories/production/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/production/group_vars/catalog-next/vars.yml
@@ -58,10 +58,10 @@ url_writable: https://{{ catalog_host_admin_next }}
 catalog_ckan_plugins_additional: [saml2auth]
 
 # login.gov identity sandbox
-saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2021"
+saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2022"
 catalog_ckan_saml2_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-production-catalog
 saml2_site_url: https://admin-catalog-next.data.gov/
-saml2_idp_url: https://secure.login.gov/api/saml/auth2021
+saml2_idp_url: https://secure.login.gov/api/saml/auth2022
 saml2_sp_private_key: "{{ catalog_next_saml2_sp_private_key }}"
 saml2_sp_public_certificate: "{{ catalog_next_saml2_sp_public_certificate }}"
 saml2_idp_entry: secure.login.gov

--- a/ansible/inventories/production/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/production/group_vars/inventory-next/vars.yml
@@ -46,7 +46,7 @@ inventory_ckan_saml2_requested_authn_context:
   - http://idmanagement.gov/ns/assurance/aal/3?hspd12=true
 
 # login.gov identity sandbox
-saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2021"
+saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2022"
 saml2_site_url: "https://inventory.data.gov/"
 
 saml2_sp_public_certificate: "{{ vault_inventory_next_saml2_sp_public_certificate }}"

--- a/ansible/inventories/staging/group_vars/catalog-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/catalog-next/vars.yml
@@ -46,10 +46,10 @@ url_writable: https://{{ catalog_host_admin_next }}
 catalog_ckan_plugins_additional: [saml2auth]
 
 # login.gov identity sandbox
-saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2021"
+saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2022"
 catalog_ckan_saml2_entity_id: urn:gov:gsa:SAML:2.0.profiles:sp:sso:gsa:datagov-staging-catalog
 saml2_site_url: "https://admin-catalog-next-datagov.dev-ocsit.bsp.gsa.gov/"
-saml2_idp_url: https://secure.login.gov/api/saml/auth2021
+saml2_idp_url: https://secure.login.gov/api/saml/auth2022
 saml2_sp_private_key: "{{ catalog_next_saml2_sp_private_key }}"
 saml2_sp_public_certificate: "{{ catalog_next_saml2_sp_public_certificate }}"
 saml2_idp_entry: secure.login.gov

--- a/ansible/inventories/staging/group_vars/inventory-next/vars.yml
+++ b/ansible/inventories/staging/group_vars/inventory-next/vars.yml
@@ -45,7 +45,7 @@ inventory_ckan_saml2_requested_authn_context:
   - http://idmanagement.gov/ns/assurance/aal/3?hspd12=true
 
 # login.gov identity sandbox
-saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2021"
+saml2_idp_metadata_url: "https://secure.login.gov/api/saml/metadata2022"
 saml2_site_url: "https://inventory-next-datagov.dev-ocsit.bsp.gsa.gov/"
 
 saml2_sp_public_certificate: "{{ vault_inventory_next_saml2_sp_public_certificate }}"


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/3659

This gets all FCS apps (catalog, jenkins, inventory-why not) updated with 2022 SAML IdP cert.

