### PR TITLE
Add script to obtain list of ckan routes

### DIFF
--- a/ckan/README.md
+++ b/ckan/README.md
@@ -1,0 +1,20 @@
+# Minimal CKAN investigation environment
+
+This directory is meant to contain scripts for the purposes of
+inspecting various live configurations.  To run these scripts, an active
+ckan environment is necessary.  This can be achieved by running `make up`
+in either the `catalog.data.gov` or `inventory-app` repositories.
+
+
+## Get all routes available in CKAN app
+
+Add the file dynamically into the docker compose volume and then run,
+
+Catalog.data.gov Prerequisites:
+- `mkdir temp` in root of repo
+- add `- ./temp:/temp` to `ckan` service volumes in `docker-compose.yml`
+- add `test_get_routes.py` to root of repo
+
+docker-compose run ckan bash -c "pip install pytest mock pylons factory-boy pytest-ckan && pytest /app/test_get_routes.py"
+
+Output file: `tmp/routes.txt`

--- a/ckan/README.md
+++ b/ckan/README.md
@@ -10,11 +10,11 @@ in either the `catalog.data.gov` or `inventory-app` repositories.
 
 Add the file dynamically into the docker compose volume and then run,
 
-Catalog.data.gov Prerequisites:
+Prerequisites:
 - `mkdir temp` in root of repo
 - add `- ./temp:/temp` to `ckan` service volumes in `docker-compose.yml`
 - add `test_get_routes.py` to root of repo
 
 docker-compose run ckan bash -c "pip install pytest mock pylons factory-boy pytest-ckan && pytest /app/test_get_routes.py"
 
-Output file: `tmp/routes.txt`
+Output file: `temp/routes.txt`

--- a/ckan/test_get_routes.py
+++ b/ckan/test_get_routes.py
@@ -1,0 +1,29 @@
+
+from ckan.tests.helpers import CKANTestApp, CKANTestClient
+import ckan.config.middleware
+from ckan.common import config
+import ckan.plugins
+
+from flask import Flask, url_for
+from  werkzeug.routing import BuildError
+import pytest
+
+# Catalog plugins
+# @pytest.mark.ckan_config('ckan.plugins', 'image_view text_view recline_view qa archiver report ckan_harvester datajson_validator datajson_harvest geodatagov datagovtheme datagov_harvest geodatagov_miscs z3950_harvester arcgis_harvester geodatagov_geoportal_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester spatial_metadata spatial_query spatial_harvest_metadata_api googleanalyticsbasic dcat dcat_json_interface structured_data datagovcatalog saml2auth envvars')
+# Inventory plugins
+@pytest.mark.ckan_config('ckan.plugins', 'datagov_inventory datastore xloader stats text_view recline_view googleanalyticsbasic s3filestore dcat_usmetadata usmetadata datajson saml2auth envvars')
+@pytest.mark.use_fixtures('with_plugins','with_request_context')
+class TestRoutes():
+
+    def test_get_routes(self, app):
+        assert ckan.plugins.plugin_loaded('envvars')
+
+        links = []
+        for rule in app.app._wsgi_app.url_map.iter_rules():
+            print(dir(rule))
+            links.append((rule.rule, rule.endpoint))
+
+        with open('/temp/routes.txt', 'w') as f:
+            for l in links:
+                f.write(str(l))
+                f.write('\n')


### PR DESCRIPTION
Related to
- #4042 

Notes:
- Add script to list registered routes in CKAN app
- Script is compatible with `catalog` and `inventory`

References:
- https://github.com/ckan/ckan/blob/master/dev-requirements.txt
- https://amercader.net/blog/replacing-ckan-web-framework/
- https://github.com/ckan/ckan/blob/2bfbfdf1cfbd8cebfa7ab51d960f00fb09e7e6f4/ckan/config/middleware/flask_app.py
- https://stackoverflow.com/questions/13317536/get-list-of-all-routes-defined-in-the-flask-app
- https://docs.ckan.org/en/2.9/contributing/architecture.html
- https://github.com/GSA/ckanext-dcat_usmetadata/blob/main/ckanext/dcat_usmetadata/tests/test_plugin.py
- https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab