### PR TITLE
Deploy reusable template

### DIFF
--- a/.github/workflows/create-services-template.yml
+++ b/.github/workflows/create-services-template.yml
@@ -1,0 +1,31 @@
+---
+name: Create Cloud.gov Services Template
+
+on:   # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      environ:
+        required: true
+        type: string
+    secrets:
+      CF_SERVICE_USER:
+        required: true
+      CF_SERVICE_AUTH:
+        required: true
+
+jobs:
+  create-cloudgov-services:
+    name: create services (${{ inputs.environ }})
+    environment: ${{ inputs.environ }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: create services
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: ./create-cloudgov-services.sh
+          cf_org: gsa-datagov
+          cf_space: ${{ inputs.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -32,10 +32,10 @@ jobs:
       matrix:
         app: ${{ fromJSON(inputs.app_names) }}
         include:
-          - app: catalog-web
-            smoketest: true
-          - app: inventory
-            smoketest: true
+          - smoketest: true
+            app: catalog-web
+          - smoketest: true
+            app: inventory
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -29,13 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        app: ${{ fromJSON(inputs.app_names) }}
-        include:
-          - smoketest: true
-            app: catalog-web
-          - smoketest: true
-            app: inventory
+      matrix: ${{ fromJSON(inputs.app_names) }}
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ ${{ inputs.app_names }} ]
+        app: ${{ fromJSON(inputs.app_names) }}
         include:
           - app: catalog-web
             smoketest: true

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           name: python-vendored
           path: vendor
+      - name: Modify robots.txt in dev
+        if: ${{ matrix.robots-dev && inputs.environ == 'development' }}
+        run: |
+          cp proxy/public/robots.develop.txt proxy/public/robots.txt
       - name: deploy ${{ matrix.app }}
         uses: cloud-gov/cg-cli-tools@main
         with:

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -1,0 +1,76 @@
+---
+name: Publish & Deploy Template
+
+on:   # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      environ:
+        required: true
+        type: string
+      app_url:
+        required: true
+        type: string
+      app_names:
+        required: true
+        type: string
+
+    secrets:
+      CF_SERVICE_USER:
+        required: true
+      CF_SERVICE_AUTH:
+        required: true
+      ADD_TO_PROJECT_PAT:
+        required: true
+
+jobs:
+  deploy:
+    name: deploy (${{ inputs.environ }})
+    environment: ${{ inputs.environ }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [ ${{ inputs.app_names }} ]
+        include:
+          - app: catalog-web
+            smoketest: true
+          - app: inventory
+            smoketest: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: python-vendored
+          path: vendor
+      - name: deploy ${{ matrix.app }}
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: >
+            cf push ${{ matrix.app }}
+            --vars-file vars.${{ inputs.environ }}.yml
+            --strategy rolling
+          cf_org: gsa-datagov
+          cf_space: ${{ inputs.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        if: ${{ matrix.smoketest }}
+        run: |
+          sleep 10
+          curl --fail --silent ${{ inputs.app_url }}\
+          /api/action/status_show?$(date +%s)
+      - name: Create Issue if it fails 😢
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          GITHUB_JOB: ${{ toJson(github)['job'] }}
+          GITHUB_ATTEMPTS: ${{ github.run_attempt }}
+          LAST_COMMIT: ${{ github.sha }}
+          LAST_RUN_BY: ${{ github.actor }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/deploy_failure.md
+          assignees: ${{ github.actor }}
+          update_existing: true


### PR DESCRIPTION
Related to
- The rest of the action consolidation work we've been doing
- https://github.com/GSA/data.gov/issues/4121

Notes:
- This is absolutely amazing!  This consolidates our deploy methodology across DEV/STAGING/PROD for both CATALOG/INVENTORY!!!
- This means that there's only one file to change if anything about our deployment changes 😄 (The only exception to this is the `vendor` step which I had issues making a reusable workflow within the same repo, let alone reusable across repos 😢)
