### PR TITLE
Static Site Reusable Worflows - Build on raw ubuntu container

### DIFF
--- a/.github/workflows/static-site-qa-template.yml
+++ b/.github/workflows/static-site-qa-template.yml
@@ -7,13 +7,13 @@ jobs:
   qa:
     name: QA Static Site
     runs-on: ubuntu-latest
-    container:
-      image: ruby:3.1
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: Install ruby dependencies
-        run: bundle
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
       - name: Build static site
         run: bundle exec jekyll build
       - name: Test External Links


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4121
- https://github.com/GSA/data.gov/issues/3513

Notes:
- build on raw ubuntu container to standardize static site build workflows
- I think this was implemented because the `ruby` image was throwing some special cases for some repos.