### PR TITLE
remove instance level restart fix

### DIFF
--- a/bin/restart-app
+++ b/bin/restart-app
@@ -9,15 +9,4 @@ elif [ -f datagov/bin/check-running-job ]; then
 fi
 check_running_job "$app_to_restart"
 
-# details here
-# https://github.com/GSA/catalog.data.gov/pull/550
-instances=$(cf app "$app_to_restart" | grep '^instances:' | sed 's/.*\///')
-if [[ $instances -le 3 ]]; then
-  cf restart "$app_to_restart" --strategy rolling
-else
-  for (( i=1; i<=instances; i++ ))
-  do
-    cf restart-app-instance "$app_to_restart" $((i-1))
-    sleep 90
-  done
-fi
+cf restart "$app_to_restart" --strategy rolling


### PR DESCRIPTION
It seems rolling restart on catalog with 5 instances is working

# Pull Request

Related to https://github.com/GSA/data.gov/pull/4185

## About

<!-- any pertinent notes -->

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [x] The actual code changes.
