### PR TITLE
Revert "Temp Fix - CI cloudfoundry reference key"

### DIFF
--- a/.github/workflows/app-restart-template.yml
+++ b/.github/workflows/app-restart-template.yml
@@ -32,7 +32,7 @@ jobs:
           repository: gsa/data.gov
           path: './datagov'
       - name: restart ${{ matrix.app }}
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: datagov/bin/check-and-renew ${{ matrix.app }} restart
           cf_org: gsa-datagov

--- a/.github/workflows/create-services-template.yml
+++ b/.github/workflows/create-services-template.yml
@@ -22,7 +22,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: create services
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: ./create-cloudgov-services.sh
           cf_org: gsa-datagov

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           cp proxy/public/robots.develop.txt proxy/public/robots.txt
       - name: deploy ${{ matrix.app }}
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: datagov/bin/check-and-renew ${{ matrix.app }} deploy ${{ inputs.environ }} --wait
           cf_org: gsa-datagov

--- a/.github/workflows/disable-egress.yml
+++ b/.github/workflows/disable-egress.yml
@@ -38,7 +38,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: disable egress
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: bin/disable-egress ${{ github.event.inputs.appName }}
           cf_org: gsa-datagov

--- a/.github/workflows/enable-egress.yml
+++ b/.github/workflows/enable-egress.yml
@@ -62,7 +62,7 @@ jobs:
           --output ${{ env.CG_DIR }}/proxy/caddy
 
       - name: enable egress
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           # tmate command for testing and debugging
           # command: apt-get -y install tmate; tmate -F

--- a/.github/workflows/restart-egress.yml
+++ b/.github/workflows/restart-egress.yml
@@ -20,7 +20,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: cf restart
-        uses: gsa/cg-cli-tools@key-not-accessible
+        uses: cloud-gov/cg-cli-tools@main
         with:
           command: bin/restart-egress
           cf_org: gsa-datagov


### PR DESCRIPTION
Related to
- GSA/catalog.data.gov#901
- https://github.com/GSA/data.gov/issues/4265

>[This issue](https://github.com/cloudfoundry/cli/issues/2390#issuecomment-1487670880) should be resolved by now. The primary reason is a new CDN security rule to fight bots. We will take additional steps to improve monitoring to respond faster to such incidents.

Hackers are only going to get worse and worse.