### PR TITLE
no vendoring for python apps

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -33,10 +33,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: python-vendored
-          path: vendor
       - name: checkout datagov
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4259

## About

Newer version of python buildpack (1.8.5 and above) is more strict on faulty vendored installs. Instead of fixing what is wrong with our CKAN app vendoring process, it is easier not to use vendored installs. 

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [x] The actual code changes.
- [ ] ~Tests written and passed.~
- [ ] ~Any changes to docs?~
- [ ] ~Any dependent PRs needed?~
