### PR TITLE
remove ckan 2.9.7 from list of ckan matrix versions to test

### DIFF
--- a/.github/workflows/ckan-test.yml
+++ b/.github/workflows/ckan-test.yml
@@ -30,10 +30,8 @@ jobs:
   test:
     strategy:
       matrix:
-        ckan-version: [2.9.7, '2.10', '2.10.1']
+        ckan-version: ['2.10', '2.10.1']
         include:
-        - ckan-version: 2.9.7
-          services-version: 2.9
         - ckan-version: '2.10'
           services-version: '2.10'
         - ckan-version: '2.10.1'


### PR DESCRIPTION
Just a white noise PR to remove CKAN version that will always fail from our testing matrix