### PR TITLE
Update GO for egress action

### DIFF
--- a/.github/workflows/enable-egress.yml
+++ b/.github/workflows/enable-egress.yml
@@ -50,9 +50,9 @@ jobs:
       # trying to emulate:
       # https://github.com/GSA/cg-egress-proxy/blob/main/Dockerfile
       - name: build caddy - setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.19.5'  # latest
+          go-version: 'stable'
       - name: build caddy - get xcaddy
         run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
       - name: build caddy - xcaddy build


### PR DESCRIPTION
Related to
- https://github.com/GSA/catalog.data.gov/issues/1019
- https://github.com/GSA/data.gov/issues/4409

Notes:
- Github complained when running Go that it was too old.