### PR TITLE
Stop deployment for same reason as restarts

### DIFF
--- a/bin/check-and-renew
+++ b/bin/check-and-renew
@@ -110,12 +110,17 @@ check_running_job "$@"
 
 if [[ "$action" == "restart" ]]; then
   if [[ $ok_to_restart == "YES" ]]; then
-      cf restart "$app_to_check" --strategy rolling
+    cf restart "$app_to_check" --strategy rolling
   else
-      echo "Restart $app_to_check cancelled."
+    echo "Restart of $app_to_check cancelled."
   fi
 fi
 
 if [[ "$action" == "deploy" ]]; then
-  cf push "$app_to_check" --vars-file vars.$space.yml --strategy rolling
+  if [[ $ok_to_restart == "YES" ]]; then
+    cf push "$app_to_check" --vars-file vars.$space.yml --strategy rolling
+  else
+    echo "Deployment for $app_to_check cancelled."
+    exit 1
+  fi
 fi


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4261

Notes:
- Stop deployment if CPU is too high or Logs are too new.
- Deployment cancellation causes hard fail (this is because if the deployment gets cancelled, the code has not been released and this requires further attention).
- Restart cancellation does not cause hard fail (this is because if a restart doesn't occur, the container is busy and will get restarted the next time.  There's no human intervention required).