### PR TITLE
Github Bash is hard

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -42,7 +42,7 @@ jobs:
           path: './datagov'
       - name: Cancel Older Versions
         run: |
-          readarray -t ids < <(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish.yml/runs" |jq '.workflow_runs[] | select(.status=="in_progress") | .id')
+          readarray -t ids < <(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish.yml/runs" |jq '.workflow_runs[] | select(.status=="in_progress") | .id');
           for id in "${ids[@]}"; do
             if [[ "$id" != "${{ github.run_id }}" ]]; then
               curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/runs/$id/cancel";

--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -42,10 +42,10 @@ jobs:
           path: './datagov'
       - name: Cancel Older Versions
         run: |
-          ids=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/gsa/${{ github.repository }}/actions/workflows/publish.yml/runs" | jq '.workflow_runs[] | select(.status=="in_progress") | .id');
+          readarray -t ids < <(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/workflows/publish.yml/runs" |jq '.workflow_runs[] | select(.status=="in_progress") | .id')
           for id in "${ids[@]}"; do
             if [[ "$id" != "${{ github.run_id }}" ]]; then
-              curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/gsa/${{ github.repository }}/actions/runs/$id/cancel";
+              curl -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${{ github.repository }}/actions/runs/$id/cancel";
             fi
           done;
       - name: Modify robots.txt in dev


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4261
- #4454 
- #4453 

Changes:
- Convert ids to array using readarray
- Add missing quote
- `github.repository` contains owner_org + repo (so no need to duplicate the org)

References:
- https://unix.stackexchange.com/a/460392
- https://unix.stackexchange.com/a/615717
- https://github.com/nickumia-reisys/github-action-test/actions/runs/6099084194