### PR TITLE
Remove timeout message

### DIFF
--- a/bin/check-and-renew
+++ b/bin/check-and-renew
@@ -125,5 +125,3 @@ if [[ "$action" == "deploy" ]]; then
     $0 "$@"
   fi
 fi
-
-echo "Action timed out"


### PR DESCRIPTION
The message `Action timed out` appears at each restart/deploy action. It is meaningless.