### PR TITLE
add new relic to allow acl

### DIFF
--- a/egress/acl/development.allow.acl
+++ b/egress/acl/development.allow.acl
@@ -1,5 +1,5 @@
-                    *.gov
-                    *.mil
+                   *.gov
+                   *.mil
     s3-us-gov-west-1.amazonaws.com
                *.hub.arcgis.com
           *.opendata.arcgis.com
@@ -21,3 +21,4 @@
                    *.tigbox.com
                 data.townofcary.org
                 data.wprdc.org
+                   *.newrelic.com

--- a/egress/acl/prod.allow.acl
+++ b/egress/acl/prod.allow.acl
@@ -1,5 +1,5 @@
-                        *.gov
-                        *.mil
+                       *.gov
+                       *.mil
         s3-us-gov-west-1.amazonaws.com
                    *.hub.arcgis.com
               *.opendata.arcgis.com
@@ -20,3 +20,4 @@
                     data.townofcary.org
                     data.wprdc.org
                     data.arlingtonva.us
+                       *.newrelic.com

--- a/egress/acl/staging.allow.acl
+++ b/egress/acl/staging.allow.acl
@@ -1,5 +1,5 @@
-                        *.gov
-                        *.mil
+                       *.gov
+                       *.mil
         s3-us-gov-west-1.amazonaws.com
                    *.hub.arcgis.com
               *.opendata.arcgis.com
@@ -21,3 +21,4 @@
                     data.townofcary.org
                     data.wprdc.org
                     data.arlingtonva.us
+                       *.newrelic.com


### PR DESCRIPTION
# Pull Request

Related to https://github.com/GSA/data.gov/issues/4474

## About

<!-- any pertinent notes -->

Adds `*.newrelic.com` to the allow.acls to allow the New Relic infrastructure agent to report home. 

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
