### PR TITLE
if the app has 0 instances, don't restart it

### DIFF
--- a/bin/restart-egress
+++ b/bin/restart-egress
@@ -2,9 +2,12 @@
 set -e
 set -o pipefail
 
-for app in $(cf apps | tail -n +4 | tr -s ' ' | cut -d ' ' -f 1)
+while read -r app_line
 do
-    cf restart "$app" --strategy rolling
-done
-
-
+    app_name=$(echo "$app_line"| tr -s ' ' | cut -d ' ' -f1)
+    app_count=$(echo "$app_line"| tr -s ' ' | cut -d ' ' -f3 | cut -d ':' -f2 | cut -d '/' -f1)
+    # restart the app if the app does not have 0 running instances
+    if [ "$app_count" -ne 0 ]; then
+        cf restart "$app_name" --strategy rolling;
+    fi
+done < <(cf apps | tail -n +4)


### PR DESCRIPTION
GH Task `restart egress proxy` has been failing for the past a couple of weeks, due to timeout when restarting the erroneous 0/0 `logstack-space-drain` app. While the reason for the timeout is unknown, there is really no need to restart an app that has 0 instance running. 