### PR TITLE
dont assign deployment failure that are auto-created

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -79,5 +79,4 @@ jobs:
           REPO: ${{ github.repository }}
         with:
           filename: datagov/.github/deploy_failure.md
-          assignees: ${{ github.actor }}
           update_existing: true


### PR DESCRIPTION
## About

We don't want to automatically assign the deployment failures to the last person who deployed. This removes that. 

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [X] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
