### PR TITLE
remove newrelic.com from allow.acl

### DIFF
--- a/egress/acl/development.allow.acl
+++ b/egress/acl/development.allow.acl
@@ -10,7 +10,6 @@
                  www.google-analytics.com
                 data.lacity.org
                 data.muni.org
-                   *.newrelic.com
                      opendataphilly.org
                  www.opendataphilly.org
                      openei.org

--- a/egress/acl/prod.allow.acl
+++ b/egress/acl/prod.allow.acl
@@ -11,7 +11,6 @@
                      www.google-analytics.com
                     data.lacity.org
                     data.muni.org
-                       *.newrelic.com
                          opendataphilly.org
                      www.opendataphilly.org
                          openei.org

--- a/egress/acl/staging.allow.acl
+++ b/egress/acl/staging.allow.acl
@@ -11,7 +11,6 @@
                      www.google-analytics.com
                     data.lacity.org
                     data.muni.org
-                       *.newrelic.com
                          opendataphilly.org
                      www.opendataphilly.org
                          openei.org


### PR DESCRIPTION
We don't need newrelic.com
- https://github.com/GSA/data.gov/issues/4474
