### PR TITLE
fix date error after busybox

### DIFF
--- a/bin/check-and-renew
+++ b/bin/check-and-renew
@@ -77,7 +77,10 @@ function check_running_job {
       # Get the time of the last line in the log (int)
       current_time=$(date --utc +%s)
       log_last_time () {
-        date --utc --date="$(cf logs --recent "$app_to_check" | tail -n 1 | awk '{split($0,time," "); print time[1]}')" +%s
+        last_time=$(cf logs --recent "$app_to_check" | tail -n 1 | awk '{split($0,time," "); print time[1]}')
+        # convert string "2024-02-01T17:02:55.83+0000" to "2024-02-01 17:02:55" for busybox date to read
+        last_time=$(echo "$last_time" | sed 's/T/ /' | sed 's/\..*//')
+        date --utc --date="$last_time" +%s
       }
 
       # First we check if any instance CPU is busy


### PR DESCRIPTION
the bin/check-and-renew has been broken for long. it is time to fix it.


![image](https://github.com/GSA/data.gov/assets/1392461/b17f91b5-2f6c-4ccf-9b3e-4783d6318ff1)


the reason it is broken is described in https://github.com/cloud-gov/cg-cli-tools/pull/23, to fix it, a sed command it added to convert string "2024-02-01T17:02:55.83+0000" to "2024-02-01 17:02:55" for busybox date to read.