### PR TITLE
Revert "fix date error after busybox"

### DIFF
--- a/bin/check-and-renew
+++ b/bin/check-and-renew
@@ -77,10 +77,7 @@ function check_running_job {
       # Get the time of the last line in the log (int)
       current_time=$(date --utc +%s)
       log_last_time () {
-        last_time=$(cf logs --recent "$app_to_check" | tail -n 1 | awk '{split($0,time," "); print time[1]}')
-        # convert string "2024-02-01T17:02:55.83+0000" to "2024-02-01 17:02:55" for busybox date to read
-        last_time=$(echo "$last_time" | sed 's/T/ /' | sed 's/\..*//')
-        date --utc --date="$last_time" +%s
+        date --utc --date="$(cf logs --recent "$app_to_check" | tail -n 1 | awk '{split($0,time," "); print time[1]}')" +%s
       }
 
       # First we check if any instance CPU is busy


### PR DESCRIPTION
This reverts commit c89442b8c2ff783cdf680e95206a1063c4bc7770 in PR https://github.com/GSA/data.gov/pull/4605.

## About

cloud-gov/cg-cli-tools has taken the [change](https://github.com/cloud-gov/cg-cli-tools/pull/23) in the cli tools, making the original fix unnecessary. 

<!-- any pertinent notes -->

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
