### PR TITLE
handle edge case

### DIFF
--- a/bin/scale_calculate.sh
+++ b/bin/scale_calculate.sh
@@ -45,7 +45,7 @@ function set_scale_direction {
 
 function set_scale_number {
   # get the total number of instances
-  total_instances=$(echo "$app_status" | grep '^instances:' | awk '{print $2}' | cut -d '/' -f 2)
+  total_instances=$(echo "$app_status" | grep '^instances:' | awk '{print $2}' | cut -d '/' -f 2 | head -n 1)
   # exit if the total instances is not a number
   if ! [[ "$total_instances" =~ ^[0-9]+$ ]]; then
     echo "Total instances is not a number. Exiting. Here is the output of the app status:"


### PR DESCRIPTION
This will stop scaling failure as in 
https://github.com/GSA/catalog.data.gov/actions/workflows/scale_web.yml?query=is%3Afailure

The cause:
The `grep` command will result in two lines output from this `$app_status` input, therefore `$total_instances` fails to be validated as a number in the `[[ "$total_instances" =~ ^[0-9]+$ ]]`  check. We only need to first line.

```
name:              catalog-web
requested state:   started
routes:            catalog-prod-datagov.apps.internal
last uploaded:     Fri 03 May 15:08:40 UTC 2024
stack:             cflinuxfs4
buildpacks:        
	name                                            version   detect output   buildpack name
	https://github.com/cloudfoundry/apt-buildpack   0.3.5                     apt
	python_buildpack                                1.8.23    python          python

type:           web
sidecars:       
instances:      5/5
memory usage:   850M
     state     since                  cpu      memory           disk           logging               details
#0   running   2024-05-03T18:45:38Z   198.5%   751.2M of 850M   869.5M of 2G   589B/s of unlimited   
#1   running   2024-05-03T18:46:11Z   243.5%   743.9M of 850M   869.5M of 2G   1.5K/s of unlimited   
#2   running   2024-05-03T18:46:40Z   187.4%   744.1M of 850M   869.5M of 2G   1.6K/s of unlimited   
#3   running   2024-05-03T18:47:12Z   305.9%   775.1M of 850M   869.5M of 2G   925B/s of unlimited   
#4   running   2024-05-03T18:47:55Z   240.0%   755.5M of 850M   869.5M of 2G   1.6K/s of unlimited   

type:           web
sidecars:       
instances:      0/1
memory usage:   850M
     state      since                  cpu    memory     disk       logging        details
#0   starting   2024-05-03T19:16:09Z   0.0%   0B of 0B   0B of 0B   0B/s of 0B/s   cat 
```