### PR TITLE
we can afford to use less catalog-web instances

### DIFF
--- a/bin/scale_calculate.sh
+++ b/bin/scale_calculate.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 MAX_INSTANCES=9
-MIN_INSTANCES=5
+MIN_INSTANCES=3
 SCALE_STEP=2
 
 CPU_BUSY_THRESHOLD=300
-CPU_IDLE_THRESHOLD=230
+CPU_IDLE_THRESHOLD=220
 
 app_status=$(cf app catalog-web)
 scale_direction=""


### PR DESCRIPTION
catalog-web has [a performance boost](https://github.com/GSA/data.gov/issues/4708). We can try with less instances. 

- change catalog-web minimum instance number from 5 to 3. 