### PR TITLE
pinning static site build template to use Ubuntu 22 LTS 

### DIFF
--- a/.github/workflows/static-site-build-template.yml
+++ b/.github/workflows/static-site-build-template.yml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
   build:
     name: Build Static Site
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # until appArmor Puppeteer issue fixed: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#issues-with-apparmor-on-ubuntu
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
...until a fix is released for Puppeteer

see more: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md\#issues-with-apparmor-on-ubuntu

# Pull Request

Related to:
- https://github.com/GSA/data.gov/issues/5024
- https://github.com/GSA/datagov-11ty/actions/runs/12674360674/job/35324046330?pr=385

## About

Tempor

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
