### PR TITLE
Add Swig System Package to CKAN 2.11

### DIFF
--- a/.github/workflows/ckan-test.yml
+++ b/.github/workflows/ckan-test.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install requirements
         run: |
-          apt-get update && apt-get install -y libgeos-dev
+          apt-get update && apt-get install -y libgeos-dev swig
           cp /usr/share/zoneinfo/America/New_York /etc/localtime
           if [ -f requirements.txt ]; then
             pip install -r requirements.txt


### PR DESCRIPTION
# Pull Request

Related to GSA/data.gov#5189

## About

Adds `swig` to system package install to accommodate for the `GSA/ckanext-dcat_usmetadata` repo

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
