### PR TITLE
Add ignore Flake8 W503

### DIFF
--- a/.github/workflows/ckan-test.yml
+++ b/.github/workflows/ckan-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Run flake8
-        run: flake8 . --count --show-source --statistics --exclude ckan
+        run: flake8 . --count --show-source --statistics --exclude ckan --ignore=W503
 
   test:
     strategy:


### PR DESCRIPTION
# Pull Request

Related to: Enhancement

## About
To better accommodate `black` formatter we should ignore Flake8 W503 (line break before binary operator), which is an opinion by flake8.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
