### PR TITLE
retry restart

### DIFF
--- a/.github/workflows/app-restart-template.yml
+++ b/.github/workflows/app-restart-template.yml
@@ -34,7 +34,24 @@ jobs:
         with:
           repository: gsa/data.gov
           path: "./datagov"
-      - name: restart ${{ matrix.app }}
+      - name: "restart ${{ matrix.app }}"
+        id: restart1
+        uses: cloud-gov/cg-cli-tools@main
+        continue-on-error: true
+        with:
+          command: datagov/bin/check-and-renew ${{ matrix.app }} restart
+          cf_org: gsa-datagov
+          cf_space: ${{ inputs.environ }}
+          cf_username: ${{secrets.CF_SERVICE_USER}}
+          cf_password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: "wait 5-30 seconds before retry"
+        if: ${{ steps.restart1.outcome == 'failure' }}
+        run: |
+          SLEEP=$(( (RANDOM % 26) + 5 ))
+          echo "Sleeping $SLEEP seconds before retry"
+          sleep "$SLEEP"
+      - name: "restart again: ${{ matrix.app }}"
+        if: ${{ steps.restart1.outcome == 'failure' }}
         uses: cloud-gov/cg-cli-tools@main
         with:
           command: datagov/bin/check-and-renew ${{ matrix.app }} restart


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5415#issuecomment-3234562794

## About

We are getting frequent 403 errors when calling api.fr.cloud.gov, possibly due to rate-limiting. This change added a retry logic, if 403 or any other error, wait for 5-30 sec, then give it another try.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
