### PR TITLE
retry restart in a new runner

### DIFF
--- a/.github/workflows/app-restart-template.yml
+++ b/.github/workflows/app-restart-template.yml
@@ -14,42 +14,41 @@ on: # yamllint disable-line rule:truthy
         required: true
         type: string
 
-    secrets:
-      CF_SERVICE_USER:
-        required: true
-      CF_SERVICE_AUTH:
-        required: true
-
 jobs:
-  restart:
-    name: restart (${{ inputs.environ }})
-    environment: ${{ inputs.environ }}
-    runs-on: ubuntu-latest
+  attempt1:
+    name: restart (${{ inputs.environ }}) attempt 1
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(inputs.app_names) }}
+    uses: ./.github/workflows/restart-attempt.yml
+    secrets: inherit
+    with:
+      environ: ${{ inputs.environ }}
+      app_url: ${{ inputs.app_url }}
+      app: ${{ matrix.app }}
+      is_retry: false
+
+  attempt2:
+    name: restart (${{ inputs.environ }}) attempt 2
+    needs: attempt1
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(inputs.app_names) }}
+    uses: ./.github/workflows/restart-attempt.yml
+    secrets: inherit
+    with:
+      environ: ${{ inputs.environ }}
+      app_url: ${{ inputs.app_url }}
+      app: ${{ matrix.app }}
+      is_retry: true
+
+  report_failures:
+    name: report failures
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    needs: [attempt1, attempt2]
+    runs-on: ubuntu-latest
     steps:
-      - name: checkout datagov
-        uses: actions/checkout@v4
-        with:
-          repository: gsa/data.gov
-          path: "./datagov"
-      - name: restart ${{ matrix.app }}
-        uses: cloud-gov/cg-cli-tools@main
-        with:
-          command: datagov/bin/check-and-renew ${{ matrix.app }} restart
-          cf_org: gsa-datagov
-          cf_space: ${{ inputs.environ }}
-          cf_username: ${{secrets.CF_SERVICE_USER}}
-          cf_password: ${{secrets.CF_SERVICE_AUTH}}
-      - name: smoke test
-        if: ${{ matrix.smoketest }}
-        run: |
-          sleep 10
-          curl --fail --silent ${{ inputs.app_url }}\
-          /api/action/status_show?$(date +%s)
       - name: Create Issue if it fails 😢
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/restart-attempt.yml
+++ b/.github/workflows/restart-attempt.yml
@@ -1,0 +1,93 @@
+---
+name: Restart Attempt
+
+on: # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      environ:
+        required: true
+        type: string
+      app_url:
+        required: false
+        type: string
+      app:
+        required: true
+        type: string
+      smoketest:
+        required: false
+        type: boolean
+        default: false
+      is_retry:
+        required: false
+        type: boolean
+        default: false
+jobs:
+  attempt:
+    name: attempt for ${{ inputs.app }} (${{ inputs.environ }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environ }}
+    env:
+      CF_ORG: gsa-datagov
+      CF_SPACE: ${{ inputs.environ }}
+    steps:
+      - name: checkout datagov
+        uses: actions/checkout@v4
+        with:
+          repository: gsa/data.gov
+          path: "./datagov"
+
+      - name: try to download success marker
+        if: ${{ inputs.is_retry }}
+        id: get_artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: restart-success-${{ inputs.environ }}-${{ inputs.app }}
+          path: success_artifact
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: check if skip
+        if: ${{ inputs.is_retry }}
+        id: gate
+        run: |
+          if [ -f success_artifact/success.txt ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: wait 5-30 seconds before attempt
+        if: ${{ inputs.is_retry && steps.gate.outputs.skip == 'false' }}
+        run: |
+          SLEEP=$(( (RANDOM % 26) + 5 ))
+          echo "Sleeping $SLEEP seconds before attempt"
+          sleep "$SLEEP"
+
+      - name: restart ${{ inputs.app }}
+        if: ${{ !inputs.is_retry || steps.gate.outputs.skip == 'false' }}
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          command: datagov/bin/check-and-renew ${{ inputs.app }} restart
+          cf_org: ${{ env.CF_ORG }}
+          cf_space: ${{ env.CF_SPACE }}
+          cf_username: ${{ secrets.CF_SERVICE_USER }}
+          cf_password: ${{ secrets.CF_SERVICE_AUTH }}
+
+      - name: smoke test
+        if: ${{ inputs.smoketest && (!inputs.is_retry || steps.gate.outputs.skip == 'false') }}
+        run: |
+          sleep 10
+          curl --fail --silent ${{ inputs.app_url }}\
+          /api/action/status_show?$(date +%s)
+
+      - name: mark success
+        if: ${{ success() && (!inputs.is_retry || steps.gate.outputs.skip == 'false') }}
+        run: echo "ok" > success.txt
+
+      - name: upload success marker
+        if: ${{ success() && (!inputs.is_retry || steps.gate.outputs.skip == 'false') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: restart-success-${{ inputs.environ }}-${{ inputs.app }}
+          path: success.txt
+          retention-days: 1


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5415#issuecomment-3234562794

## About

figured out the reasons why previous PR did not work. This PR:
- retry restart in a new runner, hopefully it means the API is calling from a new ip therefore bypassing the AWS IP block.
- passing the environment secretes correctly. 
- uses `success.txt` in the artifact to mark result of restart attempt per app, so we only restart apps that fail for the first attempt, not the whole list of apps in the matrix.
- tested, it worked for restarting app if there is no 403. Need to deploy then capture a scenario with 403 error to verify the second restart attempt works. 

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
