### PR TITLE
show runner ip for 403 debugging

### DIFF
--- a/.github/workflows/restart-attempt.yml
+++ b/.github/workflows/restart-attempt.yml
@@ -63,6 +63,13 @@ jobs:
           echo "Sleeping $SLEEP seconds before attempt"
           sleep "$SLEEP"
 
+      - name: show external IP address for 403 debugging
+        if: ${{ !inputs.is_retry || steps.gate.outputs.skip == 'false' }}
+        run: |
+          echo "External IPs:"
+          echo "checkip.amazonaws.com -> $(curl --silent https://checkip.amazonaws.com || echo 'unavailable')"
+          echo "ifconfig.me -> $(curl --silent https://ifconfig.me || echo 'unavailable')"
+
       - name: restart ${{ inputs.app }}
         if: ${{ !inputs.is_retry || steps.gate.outputs.skip == 'false' }}
         uses: cloud-gov/cg-cli-tools@main


### PR DESCRIPTION
# Pull Request

Related to
- https://github.com/GSA/data.gov/issues/5415#issuecomment-3234562794
- https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1757339680445189?thread_ts=1755790942.340729&cid=C09CR1Q9Z
## About
Minor update. Add a step to show runner id. In case of 403 error, this info help to understand more about the error. 

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
