### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # data.gov main repository
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/GSA/data.gov)
 
 ### Data.gov Actions
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/GSA/data.gov) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.