### PR TITLE
Remove *.tigbox.com

### DIFF
--- a/egress/acl/prod.allow.acl
+++ b/egress/acl/prod.allow.acl
@@ -20,7 +20,6 @@
                  bloomington.data.socrata.com
                       nycopendata.socrata.com
                              data.srcity.org
-                                *.tigbox.com
                              data.townofcary.org
      nehopendatastorage.blob.core.windows.net
                              data.wprdc.org


### PR DESCRIPTION
This domain is added to prod trouble-shooting purpose. We are done with it. 