### PR TITLE
exclude outbound link from pages not on catalog.data.gov

### DIFF
--- a/metrics/datagov_metrics/ga.py
+++ b/metrics/datagov_metrics/ga.py
@@ -120,6 +120,16 @@ def setup_organization_reports():
                                 "stringFilter": {"matchType": "EXACT", "value": "true"},
                             }
                         },
+                        {
+                            "filter": {
+                                "fieldName": "pageLocation",
+                                "stringFilter": {
+                                    "matchType": "CONTAINS",
+                                    "value": "catalog.data.gov",
+                                    "caseSensitive": False,
+                                },
+                            }
+                        },
                         org_dimension_filter,
                     ],
                 },


### PR DESCRIPTION
# Pull Request

## About

11ty tests are [failing](https://github.com/GSA/datagov-11ty/actions/runs/28125174379/job/83287026460?pr=563) because there's blank outbound links from catalog-old which are registered by google analytics. the tests fail because the anchors are empty (the empty "linkUrl"). this filters out outbound links based on the referring origin being catalog.data.gov. this is one reason why we should consider turning off catalog-old. 

once this is merged i'll rerun metrics action then 11ty tests

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
