### PR TITLE
Gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,14 @@ updates:
     versions:
     - ">= 3.0.a"
     - "< 3.1"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "*"
+    update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+  groups:
+    github-actions:
+      patterns:
+      - "*"

--- a/.github/workflows/snyk-template.yml
+++ b/.github/workflows/snyk-template.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
 


### PR DESCRIPTION
update actions/setup-node from v4 to v6 to remove the warning in the other repos when they use the snyk template

<img width="412" height="191" alt="image" src="https://github.com/user-attachments/assets/185c29ea-f7b1-4e7b-9c77-5d328c37751c" />
