### PR TITLE
update org route

### DIFF
--- a/metrics/datagov_metrics/ga.py
+++ b/metrics/datagov_metrics/ga.py
@@ -35,7 +35,7 @@ def date_range_last_month():
 
 
 def get_org_list():
-    url = "https://harvest.data.gov/organizations/?paginate=false"
+    url = "https://harvest.data.gov/api/organizations/?paginate=false"
     repo = requests.get(url)
     if repo.ok:
         return repo.json()


### PR DESCRIPTION
# Pull Request

Related to [6144](https://github.com/GSA/data.gov/issues/6144)

## About
we better defined our api and view route in [PR](https://github.com/GSA/datagov-harvester/pull/707). this change uses the correct api route. [metrics report](https://github.com/GSA/data.gov/actions/runs/28556887769/job/84900430472) is able complete without this update.

## PR TASKS

<!-- a friendly nonbinding list of reminders -->

- [ ] The actual code changes.
- [ ] Tests written and passed.
- [ ] Any changes to docs?
- [ ] Any dependent PRs needed?
