### PR TITLE
allow caller to specify ruby version

### DIFF
--- a/.github/workflows/static-site-build-template.yml
+++ b/.github/workflows/static-site-build-template.yml
@@ -2,6 +2,11 @@ name: Static Site Build & Test Template
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
+    inputs:
+      ruby-version:
+        required: false
+        type: string
+        default: "3.1"
 
 jobs:
   build:
@@ -12,7 +17,7 @@ jobs:
         uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true #runs `bundle install`
       - name: Install node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Allow callers to use different ruby versions, but keep 3.1 as default so it does not surprise old callers.

we need it when the caller app need to update ruby.