### PR TITLE
allow raw.githubusercontent.com on development space

### DIFF
--- a/egress/acl/development.allow.acl
+++ b/egress/acl/development.allow.acl
@@ -9,6 +9,7 @@
                          opendata.cityofboise.org
                              data.cityofchicago.org
                                   federallabs.org
+                              raw.githubusercontent.com
                               www.google-analytics.com
                              data.lacity.org
                              data.muni.org


### PR DESCRIPTION
allow githubusercontent.com on the `development` space so that we can test harvest from source on github.