### PR TITLE
Update default issue labels in snyk-template.yml

### DIFF
--- a/.github/workflows/snyk-template.yml
+++ b/.github/workflows/snyk-template.yml
@@ -38,7 +38,7 @@ on: # yamllint disable-line rule:truthy
         description: Comma-separated labels for scan failure issues
         required: false
         type: string
-        default: "bug,o&m,compliance"
+        default: "bug,O&M,Security - compliance"
     secrets:
       SNYK_TOKEN:
         required: true


### PR DESCRIPTION
When creating an issue in GH, the labels available are O&M,Security - compliance. Snyk scan is failing because it is trying to find o&m and compliance respectively.

## About
https://github.com/GSA/datagov-catalog/actions/runs/30789127037/job/91608808336
ISSUE_LABELS: bug,o&m,compliance
could not add label: 'o&m' not found
