### PR TITLE
6260: Enable submodule checkout so inventory-app can deploy DCAT-US schemas

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v7
+        with:
+          # cf push uploads the working tree, so any submodule the calling
+          # repo pins has to be populated here or it deploys as an empty
+          # directory. No-op for callers without submodules.
+          submodules: true
       - name: checkout datagov
         uses: actions/checkout@v7
         with:


### PR DESCRIPTION
  Related to https://github.com/GSA/data.gov/issues/6260

Adds `submodules: true` to the calling-repo checkout in `deploy-template.yml`.

**Why:** inventory-app is moving its vendored DCAT-US 3.0 JSON Schemas to a pinned git submodule at `_external/dcat-us` (GSA/dcat-us), matching GSA/datagov-harvester#887. This template runs as its own job with its own checkout, and `actions/checkout` skips submodules by default. Since `cf push` uploads the working tree, the submodule would deploy as an empty directory.

That failure is quiet, which is why this has to land first. The app boots normally and only the DCAT-US v3.0 export route 500s. The smoke test here curls `${{ inputs.app_url }}/api/action/status_show`, so the deploy goes green and the breakage shows up only in cloud.gov.

**Impact:** `actions/checkout` with `submodules: true` does nothing in a repo with no `.gitmodules`, so this is a no-op for every caller except inventory-app.

**Review notes:**
- Only the first checkout changes. The second (`repository: gsa/data.gov`, `path: ./datagov`) is untouched — this repo has no submodules.
- `true`, not `recursive`: GSA/dcat-us has no nested submodules.
- The submodule URL is HTTPS, so checkout's persisted credentials resolve it. No new secrets.
- `snyk-template.yml` is deliberately unchanged. An empty submodule there is what we want; GSA/dcat-us scans itself, and inventory-app's `.snyk` excludes `_external/**`.

## PR TASKS
- [x] The actual code changes.
- [x] Any dependent PRs needed? **This PR comes first and stands alone.** The inventory-app PR is ready to go but intentionally not open yet; it will be opened after this merges, so there's no window where inventory-app can deploy empty schemas.